### PR TITLE
UI/UX fixes: Reduce 3d viewer loading time + fix blurry renders on high-end displays

### DIFF
--- a/components/AssetPage/WebGL/GLTFViewer.tsx
+++ b/components/AssetPage/WebGL/GLTFViewer.tsx
@@ -136,6 +136,7 @@ const GLTFViewer: FC<Props> = ({ show, assetID, files }) => {
         {/* Because Canvas wraps in relative div with width/height 100% */}
         <div style={{ position: "absolute", width: "100%", height: "100%" }}>
           <Canvas
+            dpr={[1, 2]}
             camera={{ fov: 27, near: 0.1, far: 1000, position: [-(center.x + camDistance), center.y + (camDistance / 2), center.z + camDistance] }}
             onCreated={({ gl }) => { gl.toneMapping = CineonToneMapping }}
           >

--- a/components/AssetPage/WebGL/GLTFViewer.tsx
+++ b/components/AssetPage/WebGL/GLTFViewer.tsx
@@ -15,8 +15,8 @@ import {
   MeshState,
 } from './GLTF_Visibility_reducer';
 
-
 import styles from './GLTFViewer.module.scss'
+import Spinner from "components/UI/Spinner/Spinner";
 
 interface Props {
   readonly show: boolean;
@@ -57,7 +57,13 @@ const GLTFViewer: FC<Props> = ({ show, assetID, files }) => {
     return <div className={styles.wrapper}>No preview available for this model, sorry :(</div>
   }
 
-  const gltfFiles = files.gltf['4k'] ? files.gltf['4k'].gltf : files.gltf['2k'].gltf;
+  /* const gltfFiles = files.gltf["4k"] ? files.gltf["4k"].gltf
+    : files.gltf["2k"].gltf; */
+
+  // Use 2k by default
+  // TODO: check if we can load 1k first and 2k later
+  const gltfFiles = files.gltf["2k"]?.gltf || files.gltf["4k"]?.gltf;
+
   const processedGLTFFromAPI = useGLTFFromAPI(gltfFiles);
 
   // As this functionality is not really necessary, it is overkill to useReducer to handle it.
@@ -67,7 +73,7 @@ const GLTFViewer: FC<Props> = ({ show, assetID, files }) => {
   useEffect(() => {
     if (!processedGLTFFromAPI) return;
     processedGLTFFromAPI.scene.children.map(processGroup);
-  }, [processedGLTFFromAPI])
+  }, [processedGLTFFromAPI]);
 
   // Split group into children and call process group on any groups
   const processGroup = (entity) => {
@@ -86,9 +92,45 @@ const GLTFViewer: FC<Props> = ({ show, assetID, files }) => {
     handle.active ? handle.exit() : handle.enter()
   }
 
-  if (!processedGLTFFromAPI) return null;
+  // if (!processedGLTFFromAPI) return null;
 
-  return (
+  return !processedGLTFFromAPI ? (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        position: "absolute",
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: "#232323",
+          width: "100%",
+          height: "100%",
+          opacity: 0.5,
+          position: "absolute",
+          top: 0,
+          left: 0,
+          zIndex: 1,
+        }}
+      ></div>
+      <div
+        style={{
+          zIndex: 2,
+          position: "absolute",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          top: 0,
+          left: 0,
+        }}
+      >
+        <Spinner />
+      </div>
+    </div>
+  ) : (
     <FullScreen handle={handle}>
       <div className={styles.wrapper}>
         {/* Because Canvas wraps in relative div with width/height 100% */}

--- a/components/AssetPage/WebGL/useGLTFFromAPI.ts
+++ b/components/AssetPage/WebGL/useGLTFFromAPI.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { GLTF, GLTFLoader } from 'three-stdlib';
+import { GLTF } from 'three-stdlib';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
 
 interface APIDataItem {
   readonly url: string;


### PR DESCRIPTION
# TLDR

First of all: I love the project, thank you for your work! ☺️ 

After @gregzaal's talk at Blender Conf 2022, I realized that the source code is open, so I decided to make a PR that addresses some bugs I found when I first interacted with the site. I'm talking about these ones:

1. **UI:** 3D viewer loads too slow (cause: textures are too big)
2. **UX:** no response to the user while the 3D viewer is loading (at first I thought it’s not loading at all)
3. **UI:** blurry renders on devices with high device pixel ratio (e.g.: macBook, iPhone), despite the 4k textures

I can open up separate issues/PR-s for them if you want.

# Detailed explanation

## Issue 1: [UI] 3D viewer loads too slow (cause: textures are too big)

- How slow? On a M1 macBook, 50 MB/s internet:

  | ORIGINAL (4k textures) | This PR (2k textures)
-- | -- | --
loading the 3D model in the viewer from start to finish | ~6.5s | ~3s
largest texture | 5s | 1.5s

- personally, I think this speed tradeoff isn't worth it, especially considering that the renders will be blurry anyways on macBooks/iPhones/high-end displays (see **Issue 3**)
- Check this video where I compare the performance profiles (made with Firefox) of the original version of the site and my PR:

https://user-images.githubusercontent.com/43729152/200120952-b7663cfa-7850-441f-80fd-6ece78c47bbb.mp4

  - gzipped profiles:
    - [polyhaven-profile-ORIGINAL.gz](https://github.com/Poly-Haven/polyhaven.com/files/9943854/polyhaven-profile-ORIGINAL.gz)
    - [polyhaven-profile-PR.gz](https://github.com/Poly-Haven/polyhaven.com/files/9943855/polyhaven-profile-PR.gz)

## **UX:** no response to the user while the 3D viewer is loading (at first I thought it was not loading at all)
- When I first used polyhaven I thought that the 3D viewer didn’t work, because nothing happened after I clicked on the “View in 3D”-button.
- In this PR I added a loading spinner that is present until the canvas starts rendering the model
  - this PR:
  
    https://user-images.githubusercontent.com/43729152/200121235-17bc672b-3b79-4b3a-a197-c380a3e2c233.mp4
  
  - original: 
  
    https://user-images.githubusercontent.com/43729152/200121232-189d1cf6-988d-4b58-b4b9-12766b9901c5.mp4
   
## Issue 3. [UI] Blurry textures on devices with higher `devicePixelRatio` (MacBook, iPhone, etc)
- if the `dpr` is misconfigured, 4k textures might look as blurry as lower res textures
- see the differences here (**fun fact:** the sharper renders use 2k textures (the blurrier ones have 4k textures)):

     https://user-images.githubusercontent.com/43729152/200121323-5432d862-9800-4b35-bd26-adc40d1d975d.mp4
     - this pr:
       <img width="1624" alt="dpr-NEW" src="https://user-images.githubusercontent.com/43729152/200121395-9bf09894-4f36-4304-85f7-0f458de2d567.png">
     - original: 
      <img width="1580" alt="dpr-ORIGINAL" src="https://user-images.githubusercontent.com/43729152/200121401-aa3e1d4d-0c75-4f86-91c8-8f6dbbc26560.png">
      
- **cause:** this project uses an older version of `r3f`, where the `[1,2]` is not the default for the `dpr` attribute of the `<Canvas />` component.

# Closing thoughts

I can break up this PR into smaller ones if you want, or create issues for them, but I figured it'd make the communication in one place. Feel free to ask me for clarifications on my changes too!









