### PR TITLE
Fix dpr gltf viewer

### DIFF
--- a/components/AssetPage/WebGL/GLTFViewer.tsx
+++ b/components/AssetPage/WebGL/GLTFViewer.tsx
@@ -95,7 +95,7 @@ const GLTFViewer: FC<Props> = ({ show, assetID, files, onLoad }) => {
         {/* Because Canvas wraps in relative div with width/height 100% */}
         <div style={{ position: "absolute", width: "100%", height: "100%" }}>
           <Canvas
-            camera={{ fov: 27, near: 0.1, far: 1000, position: [-(center.x + camDistance), center.y + (camDistance / 2), center.z + camDistance] }}
+            dpr={[1, 2]} camera={{ fov: 27, near: 0.1, far: 1000, position: [-(center.x + camDistance), center.y + (camDistance / 2), center.z + camDistance] }}
             onCreated={({ gl }) => {
               gl.toneMapping = CineonToneMapping
               onLoad()


### PR DESCRIPTION
Here's the fix for the dpr values in its own PR, [as you asked](https://github.com/Poly-Haven/polyhaven.com/pull/50#issuecomment-1305150722). This fix is not necessary starting from `@react-three/fiber@8.0.0`, since the default value for `dpr` is already `[1, 2]` in that version (https://github.com/pmndrs/react-three-fiber/releases/tag/v8.0.0).

---
Edit:

Btw I genuinely thought that the project is not being actively developed until you told me about the `dev` branch! 😆 But it's good to see that you're still improving it. ☺️ 