### PR TITLE
[WIP] Include preview.png in zip download

### DIFF
--- a/components/AssetPage/AssetPage.tsx
+++ b/components/AssetPage/AssetPage.tsx
@@ -205,7 +205,7 @@ const AssetPage = ({ assetID, data, files, renders }) => {
           <Download
             assetID={assetID}
             data={data}
-            files={files}
+            files={{preview: `https://cdn.polyhaven.com/asset_img/primary/${assetID}.png` , ...files}}
             setPreview={setPreviewImage}
             patron={patron}
           />

--- a/components/AssetPage/Download/Download.tsx
+++ b/components/AssetPage/Download/Download.tsx
@@ -232,6 +232,15 @@ const Download = ({ assetID, data, files, setPreview, patron }) => {
         }
       }
     }
+
+    // Add the preview image to the zip
+    if (files.preview) dlFiles.push({
+      url: files.preview,
+      path: `${assetID}_preview.png`
+      // TODO: is the size of this image stored in the db?
+      // If yes, then we should get it and pass it down here
+    })
+
     startDownload(name, dlFiles)
 
     await new Promise(r => setTimeout(r, 2000)).then(_ => {

--- a/components/AssetPage/Download/DownloadOptions.tsx
+++ b/components/AssetPage/Download/DownloadOptions.tsx
@@ -71,16 +71,20 @@ const DownloadOptions = ({ open, assetID, tempUUID, files, res, fmt, selectMap, 
           !threeDFormats.includes(m) || fmt === 'zip' ?
             m !== 'nor_dx' || norMode === 'dx' || fmt === 'zip' ?
               m !== 'nor_gl' || norMode === 'gl' || fmt === 'zip' ?
-                <DownloadMap
-                  key={i}
-                  name={m}
-                  res={res}
-                  fmt={fmt}
-                  type={type}
-                  data={files[m][res]}
-                  trackDownload={trackDownload}
-                  selectMap={selectMap}
-                />
+                // TODO: should we make it possible to download the bundle
+                // without the preview in it?
+                m !== 'preview' ?
+                  <DownloadMap
+                    key={i}
+                    name={m}
+                    res={res}
+                    fmt={fmt}
+                    type={type}
+                    data={files[m][res]}
+                    trackDownload={trackDownload}
+                    selectMap={selectMap}
+                  />
+                  : null
                 : null
               : null
             : null


### PR DESCRIPTION
> :warning: This PR is still a work in progress.

## Notes
- Related issue:  https://github.com/Poly-Haven/polyhaven.com/issues/14.
- I assumed that the `preview.png` file is the image that we fetch from `https://cdn.polyhaven.com/asset_img/primary/${assetID}.png`