### PR TITLE
Improvements to GLTF model viewer

### DIFF
--- a/components/AssetPage/WebGL/GLTFViewer.module.scss
+++ b/components/AssetPage/WebGL/GLTFViewer.module.scss
@@ -15,3 +15,33 @@
   right: 0.8em;
   bottom: 0.5em;
 }
+
+.labeledButton {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  &:hover .mapLabel {
+    opacity: 1;
+    transform: translateX(0);
+    pointer-events: none;
+  }
+}
+
+.mapLabel {
+  position: absolute;
+  right: 100%;
+  padding: 0.5em 1.4em 0.6em 1.1em;
+  margin-right: -0.4em;
+  white-space: nowrap;
+  font-size: 0.85em;
+  color: $c-text-light;
+  background: $c-background-dark;
+  border: 1px solid rgba($c-text-light, 0.1);
+  border-right: none;
+  border-radius: 2em 0 0 2em;
+  opacity: 0;
+  transform: translateX(0.5em);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+}

--- a/components/AssetPage/WebGL/GLTFViewer.tsx
+++ b/components/AssetPage/WebGL/GLTFViewer.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useReducer, useState, useEffect, useMemo, Suspense } from 'react'
-import { Vector3, Quaternion, Box3, CineonToneMapping, Texture } from 'three'
-import { Canvas } from '@react-three/fiber'
-import { Environment, OrbitControls } from '@react-three/drei'
+import { Vector3, Quaternion, Box3, CineonToneMapping, Texture, type Texture as ThreeTexture } from 'three'
+import { Canvas, useFrame } from '@react-three/fiber'
+import { Environment, OrbitControls, MeshTransmissionMaterial, useFBO } from '@react-three/drei'
 import { FullScreen, useFullScreenHandle } from 'react-full-screen'
 
 import { MdPublic, MdLayers, MdLanguage, MdNotInterested, MdFullscreen } from 'react-icons/md'
@@ -26,64 +26,152 @@ interface Props {
 
 const linearMaps = ['normalMap', 'emissiveMap', 'metalnessMap', 'roughnessMap', 'aoMap']
 
-const renderMesh = (mesh, soloMap, wireframe, maxAnisotropy, transparent) => {
-  const objects = []
-  if (mesh.children) {
-    mesh.children.forEach((child) => {
-      objects.push(renderMesh(child, soloMap, wireframe, maxAnisotropy, transparent))
-    })
+const channelVertexShader = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
   }
-  objects.push(
-    <React.Fragment key={mesh.uuid}>
-      <mesh
-        geometry={mesh.geometry}
-        position={mesh.getWorldPosition(new Vector3())}
-        scale={mesh.getWorldScale(new Vector3())}
-        quaternion={mesh.getWorldQuaternion(new Quaternion())}
-      >
-        {soloMap === '' ? (
-          <meshPhysicalMaterial {...mesh.material} vertexColors={false} transparent={transparent}>
-            {Object.entries(mesh.material).map(([key, value]) =>
-              value instanceof Texture ? (
-                <texture
-                  key={key}
-                  attach={key}
-                  {...value}
-                  colorSpace={linearMaps.includes(key) ? 'srgb-linear' : 'srgb'}
-                  anisotropy={maxAnisotropy}
-                />
-              ) : null
-            )}
-          </meshPhysicalMaterial>
-        ) : (
-          <meshBasicMaterial>
-            {mesh.material['map'] && soloMap === 'DIFFUSE' && (
-              <texture attach="map" {...mesh.material['map']} anisotropy={maxAnisotropy} />
-            )}
-            {mesh.material['normalMap'] && soloMap === 'NORMAL' && (
-              <texture attach="map" {...mesh.material['normalMap']} anisotropy={maxAnisotropy} />
-            )}
-            {mesh.material['metalnessMap'] && soloMap === 'METALNESS' && (
-              <texture attach="map" {...mesh.material['metalnessMap']} anisotropy={maxAnisotropy} />
-            )}
-            {mesh.material['roughnessMap'] && soloMap === 'ROUGHNESS' && (
-              <texture attach="map" {...mesh.material['roughnessMap']} anisotropy={maxAnisotropy} />
-            )}
-          </meshBasicMaterial>
-        )}
-      </mesh>
+`
 
-      <mesh
-        geometry={mesh.geometry}
-        position={mesh.getWorldPosition(new Vector3())}
-        scale={mesh.getWorldScale(new Vector3())}
-        quaternion={mesh.getWorldQuaternion(new Quaternion())}
-      >
-        <meshStandardMaterial wireframe={true} visible={wireframe} color="black" />
-      </mesh>
-    </React.Fragment>
+const channelFragmentShader = `
+  uniform sampler2D map;
+  uniform int channel;
+  varying vec2 vUv;
+  void main() {
+    vec4 c = texture2D(map, vUv);
+    float v;
+    if (channel == 0) v = c.r;
+    else if (channel == 1) v = c.g;
+    else v = c.b;
+    gl_FragColor = vec4(v, v, v, 1.0);
+  }
+`
+
+const armChannelIndex = { AO: 0, ROUGHNESS: 1, METALNESS: 2 }
+const armTextureName = { AO: 'aoMap', ROUGHNESS: 'roughnessMap', METALNESS: 'metalnessMap' }
+
+interface SceneMeshesProps {
+  gltf: any
+  soloMap: string
+  wireframe: boolean
+  maxAnisotropy: number
+  transparent: boolean
+  transmissionBuffer: ThreeTexture
+}
+
+const collectMeshes = (node: any, result: any[] = []): any[] => {
+  if (node.type === 'Mesh' && node.material) result.push(node)
+  if (node.children) node.children.forEach((c) => collectMeshes(c, result))
+  return result
+}
+
+const SceneMeshes: FC<SceneMeshesProps> = ({ gltf, soloMap, wireframe, maxAnisotropy, transparent, transmissionBuffer }) => {
+  const meshes = useMemo(() => collectMeshes(gltf.scene), [gltf])
+
+  return (
+    <>
+      {meshes.map((mesh) => {
+        const isArmChannel = soloMap === 'AO' || soloMap === 'ROUGHNESS' || soloMap === 'METALNESS'
+        const isTransmissive = mesh.material.transmission > 0
+        const needsTransparent = transparent || mesh.material.transparent || isTransmissive
+
+        return (
+          <React.Fragment key={mesh.uuid}>
+            <mesh
+              geometry={mesh.geometry}
+              position={mesh.getWorldPosition(new Vector3())}
+              scale={mesh.getWorldScale(new Vector3())}
+              quaternion={mesh.getWorldQuaternion(new Quaternion())}
+            >
+              {soloMap === '' ? (
+                isTransmissive ? (
+                  <MeshTransmissionMaterial
+                    {...mesh.material}
+                    transmission={mesh.material.transmission}
+                    roughness={mesh.material.roughness}
+                    thickness={mesh.material.thickness ?? 0.5}
+                    chromaticAberration={0.03}
+                    buffer={transmissionBuffer}
+                    samples={6}
+                    resolution={256}
+                  >
+                    {Object.entries(mesh.material).map(([key, value]) =>
+                      value instanceof Texture ? (
+                        <texture
+                          key={key}
+                          attach={key}
+                          {...value}
+                          colorSpace={linearMaps.includes(key) ? 'srgb-linear' : 'srgb'}
+                          anisotropy={maxAnisotropy}
+                        />
+                      ) : null
+                    )}
+                  </MeshTransmissionMaterial>
+                ) : (
+                  <meshPhysicalMaterial {...mesh.material} vertexColors={false} transparent={needsTransparent}>
+                    {Object.entries(mesh.material).map(([key, value]) =>
+                      value instanceof Texture ? (
+                        <texture
+                          key={key}
+                          attach={key}
+                          {...value}
+                          colorSpace={linearMaps.includes(key) ? 'srgb-linear' : 'srgb'}
+                          anisotropy={maxAnisotropy}
+                        />
+                      ) : null
+                    )}
+                  </meshPhysicalMaterial>
+                )
+              ) : isArmChannel ? (
+                <shaderMaterial
+                  key={soloMap}
+                  vertexShader={channelVertexShader}
+                  fragmentShader={channelFragmentShader}
+                  uniforms={{
+                    map: { value: (mesh.material[armTextureName[soloMap]] ?? mesh.material.roughnessMap) ?? null },
+                    channel: { value: armChannelIndex[soloMap] },
+                  }}
+                />
+              ) : (
+                <meshBasicMaterial>
+                  {mesh.material['map'] && soloMap === 'DIFFUSE' && (
+                    <texture attach="map" {...mesh.material['map']} anisotropy={maxAnisotropy} />
+                  )}
+                  {mesh.material['normalMap'] && soloMap === 'NORMAL' && (
+                    <texture attach="map" {...mesh.material['normalMap']} anisotropy={maxAnisotropy} />
+                  )}
+                </meshBasicMaterial>
+              )}
+            </mesh>
+
+            <mesh
+              geometry={mesh.geometry}
+              position={mesh.getWorldPosition(new Vector3())}
+              scale={mesh.getWorldScale(new Vector3())}
+              quaternion={mesh.getWorldQuaternion(new Quaternion())}
+            >
+              <meshStandardMaterial wireframe={true} visible={wireframe} color="black" />
+            </mesh>
+          </React.Fragment>
+        )
+      })}
+    </>
   )
-  return objects
+}
+
+interface SceneProps extends Omit<SceneMeshesProps, 'transmissionBuffer'> {}
+
+const Scene: FC<SceneProps> = (props) => {
+  const buffer = useFBO(256, 256)
+
+  useFrame((state) => {
+    state.gl.setRenderTarget(buffer)
+    state.gl.render(state.scene, state.camera)
+    state.gl.setRenderTarget(null)
+  })
+
+  return <SceneMeshes {...props} transmissionBuffer={buffer.texture} />
 }
 
 const GLTFViewer: FC<Props> = ({ show, assetID, files, onLoad }) => {
@@ -91,10 +179,10 @@ const GLTFViewer: FC<Props> = ({ show, assetID, files, onLoad }) => {
 
   const handle = useFullScreenHandle()
 
-  const [soloMap, setSoloMap] = useState<'NORMAL' | 'METALNESS' | 'ROUGHNESS' | 'DIFFUSE' | ''>('')
+  const [soloMap, setSoloMap] = useState<'NORMAL' | 'AO' | 'ROUGHNESS' | 'METALNESS' | 'DIFFUSE' | ''>('')
   const [wireframe, setWireframe] = useState(false)
 
-  const [showEnvironment, setShowEnvironment] = useState(true)
+  const [showEnvironment, setShowEnvironment] = useState(false)
   const [envPreset, setEnvPreset] = useState<
     'warehouse' | 'sunset' | 'dawn' | 'night' | 'forest' | 'apartment' | 'studio' | 'city' | 'park' | 'lobby'
   >('warehouse')
@@ -129,11 +217,15 @@ const GLTFViewer: FC<Props> = ({ show, assetID, files, onLoad }) => {
     return <div className={styles.wrapper}>No preview available for this model, sorry :(</div>
   }
 
-  const gltfFiles = files.gltf['4k']?.gltf ?? files.gltf['2k'].gltf
+  const gltfFiles = { ...files.gltf }
   if (files['Alpha'] && files['Diffuse']) {
     gltfFiles['alpha'] = files['Diffuse']['4k']?.png ?? files['Diffuse']['2k'].png
   }
-  const processedGLTFFromAPI = useGLTFFromAPI(gltfFiles)
+  const { gltf: processedGLTFFromAPI, texturesLoaded } = useGLTFFromAPI(gltfFiles)
+
+  useEffect(() => {
+    if (texturesLoaded) onLoad()
+  }, [texturesLoaded])
 
   // As this functionality is not really necessary, it is overkill to useReducer to handle it.
   // If we need finer grained interaction per part it is useful.
@@ -170,6 +262,7 @@ const GLTFViewer: FC<Props> = ({ show, assetID, files, onLoad }) => {
         <div style={{ position: 'absolute', width: '100%', height: '100%' }}>
           <Canvas
             dpr={[1, 2]}
+            gl={{ alpha: true }}
             camera={{
               fov: 27,
               near: 0.1,
@@ -179,18 +272,27 @@ const GLTFViewer: FC<Props> = ({ show, assetID, files, onLoad }) => {
             onCreated={({ gl }) => {
               gl.toneMapping = CineonToneMapping
               setMaxAnisotropy(Math.max(1, Math.min(16, gl.capabilities.getMaxAnisotropy())))
-              onLoad()
             }}
           >
             <Suspense fallback={null}>
               <Environment preset={envPreset} background={showEnvironment} />
+              {!texturesLoaded && (
+                <>
+                  <ambientLight intensity={1.5} />
+                  <directionalLight intensity={10.5} position={[5, 10, 5]} />
+                </>
+              )}
               <OrbitControls enablePan={true} enableZoom={true} enableRotate={true} target={center} />
 
-              {processedGLTFFromAPI &&
-                state.meshes &&
-                Object.values(state.meshes).map((node) =>
-                  renderMesh(node.mesh, soloMap, wireframe, maxAnisotropy, !!gltfFiles['alpha'])
-                )}
+              {processedGLTFFromAPI && (
+                <Scene
+                  gltf={processedGLTFFromAPI}
+                  soloMap={soloMap}
+                  wireframe={wireframe}
+                  maxAnisotropy={maxAnisotropy}
+                  transparent={!!gltfFiles['alpha']}
+                />
+              )}
             </Suspense>
           </Canvas>
         </div>
@@ -231,27 +333,56 @@ const GLTFViewer: FC<Props> = ({ show, assetID, files, onLoad }) => {
             }}
           />
           <IconButton icon={<MdLayers />}>
-            <IconButton
-              icon={<img src={`https://cdn.polyhaven.com/site_images/map_types/DIFFUSE.png?width=32`} />}
-              active={soloMap === 'DIFFUSE'}
-              onClick={() => {
-                setSoloMap('DIFFUSE')
-              }}
-            />
-            <IconButton
-              icon={<img src={`https://cdn.polyhaven.com/site_images/map_types/NORMAL.png?width=32`} />}
-              active={soloMap === 'NORMAL'}
-              onClick={() => {
-                setSoloMap('NORMAL')
-              }}
-            />
-            <IconButton
-              icon={<img src={`https://cdn.polyhaven.com/site_images/map_types/METALNESS.png?width=32`} />}
-              active={soloMap === 'METALNESS'}
-              onClick={() => {
-                setSoloMap('METALNESS')
-              }}
-            />
+            <div className={styles.labeledButton}>
+              <span className={styles.mapLabel}>Base Color</span>
+              <IconButton
+                icon={<img src={`https://cdn.polyhaven.com/site_images/map_types/DIFFUSE.png?width=32`} />}
+                active={soloMap === 'DIFFUSE'}
+                onClick={() => {
+                  setSoloMap('DIFFUSE')
+                }}
+              />
+            </div>
+            <div className={styles.labeledButton}>
+              <span className={styles.mapLabel}>Normal</span>
+              <IconButton
+                icon={<img src={`https://cdn.polyhaven.com/site_images/map_types/NORMAL.png?width=32`} />}
+                active={soloMap === 'NORMAL'}
+                onClick={() => {
+                  setSoloMap('NORMAL')
+                }}
+              />
+            </div>
+            <div className={styles.labeledButton}>
+              <span className={styles.mapLabel}>Ambient Occlusion</span>
+              <IconButton
+                icon={<img src={`https://cdn.polyhaven.com/site_images/map_types/AO.png?width=32`} />}
+                active={soloMap === 'AO'}
+                onClick={() => {
+                  setSoloMap('AO')
+                }}
+              />
+            </div>
+            <div className={styles.labeledButton}>
+              <span className={styles.mapLabel}>Roughness</span>
+              <IconButton
+                icon={<img src={`https://cdn.polyhaven.com/site_images/map_types/ROUGHNESS.png?width=32`} />}
+                active={soloMap === 'ROUGHNESS'}
+                onClick={() => {
+                  setSoloMap('ROUGHNESS')
+                }}
+              />
+            </div>
+            <div className={styles.labeledButton}>
+              <span className={styles.mapLabel}>Metalness</span>
+              <IconButton
+                icon={<img src={`https://cdn.polyhaven.com/site_images/map_types/METALNESS.png?width=32`} />}
+                active={soloMap === 'METALNESS'}
+                onClick={() => {
+                  setSoloMap('METALNESS')
+                }}
+              />
+            </div>
             <IconButton
               icon={<img src={`https://cdn.polyhaven.com/asset_img/thumbs/rough_wood.png?width=32`} />}
               active={soloMap === ''}

--- a/components/AssetPage/WebGL/useGLTFFromAPI.ts
+++ b/components/AssetPage/WebGL/useGLTFFromAPI.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { GLTF, GLTFLoader } from 'three-stdlib'
+import { MeshStandardMaterial } from 'three'
 
 interface APIDataItem {
   readonly url: string
@@ -7,52 +8,125 @@ interface APIDataItem {
   readonly md5: string
 }
 
-interface GLTFFromAPI extends APIDataItem {
+interface GLTFResolution extends APIDataItem {
   readonly include: { [s: string]: APIDataItem }
-  readonly alpha: APIDataItem
 }
 
-export const useGLTFFromAPI = (APIModelObject: GLTFFromAPI): GLTF => {
-  const [mappedGLTF, setMappedGLTF] = useState()
-  const [processedGLTF, setProcessedGLTF] = useState<GLTF>()
+export interface GLTFFiles {
+  readonly '1k'?: { gltf: GLTFResolution }
+  readonly '2k'?: { gltf: GLTFResolution }
+  readonly '4k'?: { gltf: GLTFResolution }
+  alpha?: APIDataItem
+}
+
+// 1x1 transparent PNG so GLTFLoader skips texture fetches in the first pass.
+const STUB_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+
+const buildMappedGLTF = (data: any, res: GLTFResolution, alpha: APIDataItem | undefined, stubTextures: boolean) => ({
+  ...data,
+  images: data.images.map((img: { uri: string }) => {
+    if (alpha && (img.uri.endsWith('_diff_4k.jpg') || img.uri.endsWith('_diff_2k.jpg') || img.uri.endsWith('_diff_1k.jpg'))) {
+      return stubTextures ? { ...img, mimeType: 'image/png', uri: STUB_PNG } : { ...img, mimeType: 'image/png', uri: alpha.url }
+    }
+    return stubTextures
+      ? { ...img, mimeType: 'image/png', uri: STUB_PNG }
+      : { ...img, uri: res.include[img.uri].url }
+  }),
+  buffers: data.buffers.map((buf: { uri: string }) => ({
+    byteLength: res.include[buf.uri].size,
+    uri: res.include[buf.uri].url,
+  })),
+  // When stubbing, force matte white so the model doesn't look fully metallic.
+  materials: stubTextures
+    ? data.materials?.map((mat: any) => ({
+        ...mat,
+        pbrMetallicRoughness: {
+          ...mat.pbrMetallicRoughness,
+          metallicFactor: 0,
+          roughnessFactor: 1,
+          metallicRoughnessTexture: undefined,
+        },
+        normalTexture: undefined,
+        occlusionTexture: undefined,
+      }))
+    : data.materials,
+})
+
+const applyAOMaps = (gltf: GLTF) => {
+  gltf.scene.traverse((obj: any) => {
+    if (!obj.isMesh) return
+    const mat = obj.material as MeshStandardMaterial
+    if (mat && !mat.aoMap && mat.roughnessMap) {
+      mat.aoMap = mat.roughnessMap
+      mat.aoMap.channel = 0 // red channel of ARM texture
+      mat.aoMapIntensity = 1
+      mat.needsUpdate = true
+    }
+  })
+}
+
+export interface ProgressiveGLTF {
+  gltf: GLTF | undefined
+  texturesLoaded: boolean
+}
+
+export const useGLTFFromAPI = (files: GLTFFiles): ProgressiveGLTF => {
+  const [gltf, setGltf] = useState<GLTF>()
+  const [texturesLoaded, setTexturesLoaded] = useState(false)
+
+  const initialRes = (files['1k'] ?? files['2k'] ?? files['4k'])!
+  const finalRes = (files['4k'] ?? files['2k'] ?? files['1k'])!
 
   useEffect(() => {
-    fetch(APIModelObject.url)
+    let cancelled = false
+
+    fetch(initialRes.gltf.url)
       .then((res) => res.json())
       .then((data) => {
-        setMappedGLTF({
-          ...data,
-          images: data.images.map((key, idx) => {
-            if (APIModelObject.alpha && (key.uri.endsWith('_diff_4k.jpg') || key.uri.endsWith('_diff_2k.jpg'))) {
-              return {
-                ...data.images[idx],
-                mimeType: 'image/png',
-                uri: APIModelObject.alpha.url,
-              }
+        if (cancelled) return
+
+        // Phase 1
+        const loader = new GLTFLoader()
+        loader.parse(
+          JSON.stringify(buildMappedGLTF(data, initialRes.gltf, files.alpha, true)),
+          'https://dl.polyhaven.com/',
+          (parsed) => {
+            if (cancelled) return
+            setGltf(parsed)
+
+            // Phase 2: re-parse with real textures and swap the scene.
+            const loadFull = (fullData: any) => {
+              if (cancelled) return
+              const fullLoader = new GLTFLoader()
+              fullLoader.parse(
+                JSON.stringify(buildMappedGLTF(fullData, finalRes.gltf, files.alpha, false)),
+                'https://dl.polyhaven.com/',
+                (fullParsed) => {
+                  if (!cancelled) {
+                    applyAOMaps(fullParsed)
+                    setGltf(fullParsed)
+                    setTexturesLoaded(true)
+                  }
+                }
+              )
             }
-            return {
-              ...data.images[idx],
-              uri: APIModelObject.include[key.uri].url,
+
+            if (finalRes.gltf.url === initialRes.gltf.url) {
+              loadFull(data)
+            } else {
+              fetch(finalRes.gltf.url)
+                .then((r) => r.json())
+                .then(loadFull)
             }
-          }),
-          buffers: data.buffers.map((key) => {
-            return {
-              byteLength: APIModelObject.include[key.uri].size,
-              uri: APIModelObject.include[key.uri].url,
-            }
-          }),
-        })
+          }
+        )
       })
-  }, [])
 
-  useEffect(() => {
-    if (!mappedGLTF) return
-    const _GLTFLoader = new GLTFLoader()
+    return () => {
+      cancelled = true
+    }
+  }, [initialRes.gltf.url])
 
-    // should not hard code baseUrl here, get from API
-    // can also use deeper nesting but most importantly it is just needed to make glTF URLs relative
-    _GLTFLoader.parse(JSON.stringify(mappedGLTF), 'https://dl.polyhaven.com/', (data) => setProcessedGLTF(data))
-  }, [mappedGLTF])
-
-  return processedGLTF
+  return { gltf, texturesLoaded }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "ignoreDeprecations": "6.0"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
- Opens faster by loading the model without textures first
- Now allows viewing ao, roughness and metallic separately instead of ARM (new icons need to be added)
- Rendered view now includes ambient occlusion, leading to much nicer visuals
- Transmission rendering support
- Loads with hdri hidden by default for less visual clutter and parity with pre-rendered images.