### PR TITLE
SEO, accessibility and PageSpeed improvements

### DIFF
--- a/components/AssetPage/AssetPage.tsx
+++ b/components/AssetPage/AssetPage.tsx
@@ -58,8 +58,10 @@ const AssetPage = ({ assetID, data, files, renders, postDownloadStats }) => {
   const [hideSidebar, setHideSidebar] = useState(true)
   const [shouldLoadUserRenders, setShouldLoadUserRenders] = useState(false)
   const widthRef = useRef(null)
+  const previewRef = useRef(null)
   const userRendersRef = useRef(null)
   const { width: sidebarWidth } = useDivSize(widthRef)
+  const { width: previewWidth } = useDivSize(previewRef)
 
   const authors = Object.keys(data.authors).sort()
   const multiAuthor = authors.length > 1
@@ -125,6 +127,11 @@ const AssetPage = ({ assetID, data, files, renders, postDownloadStats }) => {
     }
   }, [assetID])
 
+  useEffect(() => {
+    if (!previewWidth) return
+    setActiveImage(`${activeImageSrc}?height=${Math.round(previewWidth / 2)}&quality=95`)
+  }, [previewWidth])
+
   // Intersection Observer for UserRenders lazy loading
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -158,6 +165,8 @@ const AssetPage = ({ assetID, data, files, renders, postDownloadStats }) => {
     setShowTilePreview('')
   }
 
+  const previewHeight = previewWidth ? Math.round(previewWidth / 2) : 760
+
   const setPreviewImage = (src) => {
     if (!activeImage.startsWith(src)) {
       setImageLoading(true)
@@ -167,7 +176,7 @@ const AssetPage = ({ assetID, data, files, renders, postDownloadStats }) => {
     }
     setActiveImageSrc(src)
     if (src.startsWith('https://cdn.polyhaven.com/')) {
-      src += '?height=760&quality=95'
+      src += `?height=${previewHeight}&quality=95`
     }
     setActiveImage(src)
     setShowTilePreview('')
@@ -211,7 +220,7 @@ const AssetPage = ({ assetID, data, files, renders, postDownloadStats }) => {
           </div>
         </div>
 
-        <div className={styles.previewWrapper}>
+        <div className={styles.previewWrapper} ref={previewRef}>
           <div className={`${styles.activePreview}${showWebGL ? ' ' + styles.activePreviewGLTF : ''}`}>
             <img id="activePreview" onLoad={imageLoaded} src={activeImage} alt={data.description} />
             {data.sketchfab_id ? (

--- a/components/AssetPage/AssetPage.tsx
+++ b/components/AssetPage/AssetPage.tsx
@@ -58,10 +58,8 @@ const AssetPage = ({ assetID, data, files, renders, postDownloadStats }) => {
   const [hideSidebar, setHideSidebar] = useState(true)
   const [shouldLoadUserRenders, setShouldLoadUserRenders] = useState(false)
   const widthRef = useRef(null)
-  const previewRef = useRef(null)
   const userRendersRef = useRef(null)
   const { width: sidebarWidth } = useDivSize(widthRef)
-  const { width: previewWidth } = useDivSize(previewRef)
 
   const authors = Object.keys(data.authors).sort()
   const multiAuthor = authors.length > 1
@@ -127,11 +125,6 @@ const AssetPage = ({ assetID, data, files, renders, postDownloadStats }) => {
     }
   }, [assetID])
 
-  useEffect(() => {
-    if (!previewWidth) return
-    setActiveImage(`${activeImageSrc}?height=${Math.round(previewWidth / 2)}&quality=95`)
-  }, [previewWidth])
-
   // Intersection Observer for UserRenders lazy loading
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -165,8 +158,6 @@ const AssetPage = ({ assetID, data, files, renders, postDownloadStats }) => {
     setShowTilePreview('')
   }
 
-  const previewHeight = previewWidth ? Math.round(previewWidth / 2) : 760
-
   const setPreviewImage = (src) => {
     if (!activeImage.startsWith(src)) {
       setImageLoading(true)
@@ -176,7 +167,7 @@ const AssetPage = ({ assetID, data, files, renders, postDownloadStats }) => {
     }
     setActiveImageSrc(src)
     if (src.startsWith('https://cdn.polyhaven.com/')) {
-      src += `?height=${previewHeight}&quality=95`
+      src += '?height=760&quality=95'
     }
     setActiveImage(src)
     setShowTilePreview('')
@@ -220,7 +211,7 @@ const AssetPage = ({ assetID, data, files, renders, postDownloadStats }) => {
           </div>
         </div>
 
-        <div className={styles.previewWrapper} ref={previewRef}>
+        <div className={styles.previewWrapper}>
           <div className={`${styles.activePreview}${showWebGL ? ' ' + styles.activePreviewGLTF : ''}`}>
             <img id="activePreview" onLoad={imageLoaded} src={activeImage} alt={data.description} />
             {data.sketchfab_id ? (

--- a/components/AssetPage/Carousel/Carousel.module.scss
+++ b/components/AssetPage/Carousel/Carousel.module.scss
@@ -31,6 +31,7 @@
 
   img {
     max-width: 100%;
+    max-height: 110px;
     position: relative;
   }
 

--- a/components/AssetPage/Carousel/Carousel.module.scss
+++ b/components/AssetPage/Carousel/Carousel.module.scss
@@ -17,6 +17,7 @@
   cursor: pointer;
   min-width: 50px;
   max-width: 250px;
+  height: calc(110px + 0.4em + 2px);
 
   &:hover {
     filter: brightness(1.1);

--- a/components/AssetPage/Carousel/Carousel.tsx
+++ b/components/AssetPage/Carousel/Carousel.tsx
@@ -73,7 +73,7 @@ const Carousel = ({ slug, data, files, assetType, setter, showWebGL, showTilePre
           onClick={clickImage}
           className={`${styles.image} ${active === images[i] ? styles.activeImage : ''}`}
         >
-          <img src={images[i] + '?height=110&quality=95'} height={110} alt={i} />
+          <img src={images[i] + '?height=110&quality=95'} alt={i} />
           {Object.keys(image_info).includes(i) ? (
             <div className={styles.credit}>
               <p>

--- a/components/AssetPage/Carousel/Carousel.tsx
+++ b/components/AssetPage/Carousel/Carousel.tsx
@@ -73,7 +73,7 @@ const Carousel = ({ slug, data, files, assetType, setter, showWebGL, showTilePre
           onClick={clickImage}
           className={`${styles.image} ${active === images[i] ? styles.activeImage : ''}`}
         >
-          <img src={images[i] + '?height=110&quality=95'} />
+          <img src={images[i] + '?height=110&quality=95'} height={110} alt={i} />
           {Object.keys(image_info).includes(i) ? (
             <div className={styles.credit}>
               <p>
@@ -120,6 +120,7 @@ const Carousel = ({ slug, data, files, assetType, setter, showWebGL, showTilePre
                     src={`https://cdn.polyhaven.com/asset_img/map_previews/${slug}/${urlBaseName(
                       maps[m]
                     )}?height=50&width=50&quality=95`}
+                    alt={m}
                   />
                 </div>
               ))}

--- a/components/AssetPage/Download/Download.tsx
+++ b/components/AssetPage/Download/Download.tsx
@@ -498,7 +498,7 @@ const Download = ({ assetID, data, files, setPreview, patron, texelDensity, call
         />
 
         <a
-          href={isHDRI ? files['hdri'][dlRes][dlFmt].url : null}
+          href={isHDRI ? files['hdri'][dlRes][dlFmt].url : '#'}
           target="_blank"
           rel="noopener"
           className={`${styles.downloadBtn} ${busyDownloading ? styles.disabled : null}`}
@@ -508,7 +508,10 @@ const Download = ({ assetID, data, files, setPreview, patron, texelDensity, call
                   setDownloadError(null) // Clear any previous errors
                   trackDownload()
                 }
-              : downloadZip
+              : (e) => {
+                  e.preventDefault()
+                  downloadZip()
+                }
           }
         >
           <MdFileDownload />

--- a/components/CorporateSponsors/CorporateSponsors.tsx
+++ b/components/CorporateSponsors/CorporateSponsors.tsx
@@ -33,7 +33,7 @@ const CorporateSponsors = ({ header, home, hideInfoBtn }) => {
       <h2>
         {header}
         {!hideInfoBtn && (
-          <Link href="/corporate">
+          <Link href="/corporate" aria-label="Corporate sponsors info">
             <MdInfoOutline />
           </Link>
         )}

--- a/components/Home/Avatar.tsx
+++ b/components/Home/Avatar.tsx
@@ -7,7 +7,7 @@ const Avatar = ({ id, name, role, country }) => {
 
   return (
     <div className={styles.avatar}>
-      <img src={`https://cdn.polyhaven.com/people/${id}.jpg?width=${size}&quality=95`} width={size} height={size} />
+      <img src={`https://cdn.polyhaven.com/people/${id}.jpg?width=${size}&quality=95`} width={size} height={size} alt={name} />
       <div className={styles.avatarInfo}>
         <CountryFlag code={country} />
         <strong>{name}</strong>

--- a/components/Home/Home.tsx
+++ b/components/Home/Home.tsx
@@ -1,4 +1,5 @@
 import { useTranslation, Trans } from 'next-i18next'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import LinkText from 'components/LinkText/LinkText'
 import apiSWR from 'utils/apiSWR'
@@ -10,9 +11,10 @@ import LatestPatrons from './LatestPatrons'
 import SocialIcons from 'components/UI/Icons/SocialIcons/SocialIcons'
 import CorporateSponsors from 'components/CorporateSponsors/CorporateSponsors'
 import Staff from 'components/UI/Avatar/Staff'
-import Gallery from 'components/Gallery/Gallery'
 import Loader from 'components/UI/Loader/Loader'
-import Roadmap from 'components/Roadmap/Roadmap'
+
+const Gallery = dynamic(() => import('components/Gallery/Gallery'), { ssr: false })
+const Roadmap = dynamic(() => import('components/Roadmap/Roadmap'), { ssr: false })
 
 import styles from './Home.module.scss'
 
@@ -30,12 +32,13 @@ const Home = () => {
       <div className={styles.sectionWrapper}>
         <div className={styles.assetTypeBanner}>
           <div className={`${styles.subSection} ${styles.subSectionHDRI}`}>
-            <Link href="/hdris">
+            <Link href="/hdris" aria-label="HDRIs">
               <div className={styles.assetTypeImage}>
-                <img src="https://cdn.polyhaven.com/site_images/home/balls/hdri.png?width=300&quality=95" />
+                <img src="https://cdn.polyhaven.com/site_images/home/balls/hdri.png?width=150&quality=85" alt="HDRIs" />
                 <img
-                  src="https://cdn.polyhaven.com/site_images/home/balls/hdri_h.png?width=300&quality=95"
+                  src="https://cdn.polyhaven.com/site_images/home/balls/hdri_h.png?width=150&quality=85"
                   className={styles.hover}
+                  alt=""
                 />
               </div>
             </Link>
@@ -46,12 +49,13 @@ const Home = () => {
             </div>
           </div>
           <div className={`${styles.subSection} ${styles.subSectionTex}`}>
-            <Link href="/textures">
+            <Link href="/textures" aria-label="Textures">
               <div className={styles.assetTypeImage}>
-                <img src="https://cdn.polyhaven.com/site_images/home/balls/tex.png?width=300&quality=95" />
+                <img src="https://cdn.polyhaven.com/site_images/home/balls/tex.png?width=150&quality=85" alt="Textures" />
                 <img
-                  src="https://cdn.polyhaven.com/site_images/home/balls/tex_h.png?width=300&quality=95"
+                  src="https://cdn.polyhaven.com/site_images/home/balls/tex_h.png?width=150&quality=85"
                   className={styles.hover}
+                  alt=""
                 />
               </div>
             </Link>
@@ -62,12 +66,13 @@ const Home = () => {
             </div>
           </div>
           <div className={`${styles.subSection} ${styles.subSectionMod}`}>
-            <Link href="/models">
+            <Link href="/models" aria-label="Models">
               <div className={styles.assetTypeImage}>
-                <img src="https://cdn.polyhaven.com/site_images/home/balls/mod.png?width=300&quality=95" />
+                <img src="https://cdn.polyhaven.com/site_images/home/balls/mod.png?width=150&quality=85" alt="Models" />
                 <img
-                  src="https://cdn.polyhaven.com/site_images/home/balls/mod_h.png?width=300&quality=95"
+                  src="https://cdn.polyhaven.com/site_images/home/balls/mod_h.png?width=150&quality=85"
                   className={styles.hover}
+                  alt=""
                 />
               </div>
             </Link>
@@ -286,7 +291,7 @@ const Home = () => {
         <div className={styles.moreGallery}>
           <div className={styles.spacer} />
           <div style={{ pointerEvents: 'initial' }}>
-            <Button text={t('home:s7b')} href="/gallery" />
+            <Button text={t('home:s7b')} href="/gallery" ariaLabel={t('home:s7b_aria')} />
           </div>
         </div>
       </div>

--- a/components/Home/Slider/Slider.tsx
+++ b/components/Home/Slider/Slider.tsx
@@ -156,7 +156,7 @@ const Slider = () => {
       aspect_ratio: `${width}:${height}`,
       width: width * window.devicePixelRatio,
       height: height * window.devicePixelRatio,
-      quality: 95,
+      quality: 87,
     }
     const urlParamsStr = Object.entries(urlParams)
       .map(([k, v]) => `${k}=${v}`)
@@ -231,7 +231,7 @@ const Slider = () => {
         <SliderLogoDynamic containerWidth={width} containerHeight={height} />
       ) : (
         <>
-          <img src="/Logo 256.png" className={styles.logo} />
+          <img src="/Logo 256.png" className={styles.logo} alt="Poly Haven logo" />
           <h1>Poly Haven</h1>
           <p>{t('tagline')}</p>
         </>

--- a/components/Home/Slider/SliderLogo.tsx
+++ b/components/Home/Slider/SliderLogo.tsx
@@ -65,7 +65,7 @@ const SliderLogo = ({ containerWidth, containerHeight }) => {
         top: posY,
       }}
     >
-      <img src="/Logo 256.png" className={styles.logo} style={{ marginBottom: '-0.35em' }} />
+      <img src="/Logo 256.png" className={styles.logo} style={{ marginBottom: '-0.35em' }} alt="Poly Haven logo" />
       <h1>Poly Haven</h1>
       <p>{t('tagline')}</p>
     </div>

--- a/components/Layout/Footer/Footer.module.scss
+++ b/components/Layout/Footer/Footer.module.scss
@@ -96,6 +96,8 @@
 
   .logo {
     height: 5rem;
+    width: auto;
+    aspect-ratio: 1 / 1;
   }
 
   h1 {

--- a/components/Layout/Footer/Footer.tsx
+++ b/components/Layout/Footer/Footer.tsx
@@ -16,7 +16,7 @@ const footer = () => {
   const router = useRouter()
 
   return (
-    <div id={styles.footer} dir={['ar', 'fa', 'he'].includes(router.locale) ? 'rtl' : 'ltr'}>
+    <footer id={styles.footer} dir={['ar', 'fa', 'he'].includes(router.locale) ? 'rtl' : 'ltr'}>
       <h2>
         <Trans
           i18nKey="common:footer.thanks"
@@ -47,7 +47,7 @@ const footer = () => {
         <div className={styles.links}>
           <Link href="/">
             <div className={styles.logoWrapper}>
-              <img src="/Logo 256.png" className={styles.logo} />
+              <img src="/Logo 256.png" className={styles.logo} width={140} height={140} alt="Poly Haven logo" />
               <h1>Poly Haven</h1>
               <p>{t('common:tagline')}</p>
             </div>
@@ -112,7 +112,7 @@ const footer = () => {
           <SocialIcons />
         </div>
       </div>
-    </div>
+    </footer>
   )
 }
 

--- a/components/Layout/Header/Header.tsx
+++ b/components/Layout/Header/Header.tsx
@@ -6,10 +6,10 @@ import styles from './Header.module.scss'
 
 const header = () => {
   return (
-    <div className={styles.header} id="mainheader">
+    <header className={styles.header} id="mainheader">
       <Link href="/" className={styles.logo}>
         <div className={styles.logo_image}>
-          <img src="/Logo 256.png" />
+          <img src="/Logo 256.png" alt="Poly Haven logo" />
         </div>
         Poly Haven
       </Link>
@@ -21,7 +21,7 @@ const header = () => {
       <div style={{ display: 'none' }} id="header-frompath" />
       <div className={styles.spacer} />
       <Nav />
-    </div>
+    </header>
   )
 }
 

--- a/components/Layout/Header/Nav/Nav.tsx
+++ b/components/Layout/Header/Nav/Nav.tsx
@@ -89,7 +89,7 @@ const Nav = () => {
 
   return (
     <>
-      <div
+      <nav
         className={`${styles.nav} ${navHide ? styles.hiddenMobile : null}`}
         onClick={() => {
           setToggle(true)
@@ -185,13 +185,13 @@ const Nav = () => {
         </NavItem>
 
         {user ? (
-          <NavItem text={<MdAccountCircle />} link="/account">
+          <NavItem text={<MdAccountCircle />} link="/account" ariaLabel={t('common:nav.account')}>
             <NavItem text={t('common:nav.logout')} link="/api/auth/logout" />
           </NavItem>
         ) : (
-          <NavItem text={<IoMdLogIn />} link={`/account?returnTo=${router.asPath}`} />
+          <NavItem text={<IoMdLogIn />} link={`/account?returnTo=${router.asPath}`} ariaLabel={t('common:nav.login')} />
         )}
-      </div>
+      </nav>
 
       <div style={{ height: '100%', display: 'flex' }}>
         {suggestedLocale && suggestLocale ? (

--- a/components/Layout/Header/Nav/NavItem.tsx
+++ b/components/Layout/Header/Nav/NavItem.tsx
@@ -10,6 +10,7 @@ const NavItem = ({
   onMouseEnter = null,
   children = null,
   lighthouse = false,
+  ariaLabel = null,
 }) => {
   return (
     <div
@@ -20,11 +21,11 @@ const NavItem = ({
     >
       {link ? (
         locale ? (
-          <a href={`${locale === 'en' ? '' : `/${locale}`}${link}`} className={styles.navItem}>
+          <a href={`${locale === 'en' ? '' : `/${locale}`}${link}`} className={styles.navItem} aria-label={ariaLabel}>
             {text}
           </a>
         ) : (
-          <Link href={link} className={styles.navItem}>
+          <Link href={link} className={styles.navItem} aria-label={ariaLabel}>
             {text}
           </Link>
         )

--- a/components/Layout/Page/Page.tsx
+++ b/components/Layout/Page/Page.tsx
@@ -10,7 +10,7 @@ const Page = ({ children, immersiveScroll, library, assetPage }) => {
         assetPage ? styles.assetPage : ''
       }`}
     >
-      <div className={styles.pageContent}>{children}</div>
+      <main className={styles.pageContent}>{children}</main>
       <Footer />
     </div>
   )

--- a/components/Library/Grid/GridItem/GridItem.tsx
+++ b/components/Library/Grid/GridItem/GridItem.tsx
@@ -43,6 +43,7 @@ const GridItem = ({ asset, assetID, onClick, blurUpcoming, thumbSize, showText }
     },
   }
   const size = Object.values(sizes)[asset.type][thumbSize]
+  const quality = 87
 
   const blur = blurUpcoming && daysOld(asset.date_published) < 0
 
@@ -132,7 +133,7 @@ const GridItem = ({ asset, assetID, onClick, blurUpcoming, thumbSize, showText }
     creditedAuthors = Object.keys(asset.authors)
   }
 
-  const img_src = `https://cdn.polyhaven.com/asset_img/thumbs/${assetID}.png?width=${size[0]}&height=${size[1]}&quality=95`
+  const img_src = `https://cdn.polyhaven.com/asset_img/thumbs/${assetID}.png?width=${size[0]}&height=${size[1]}&quality=${quality}`
   return (
     <Link
       href="/a/[id]"

--- a/components/Roadmap/Roadmap.tsx
+++ b/components/Roadmap/Roadmap.tsx
@@ -16,10 +16,10 @@ const Milestone = ({ milestone, active, achieved }) => {
   const Comp = active || achieved ? Link : 'div'
 
   return (
-    <Comp href={milestone.link} className={styles.milestoneText}>
+    <Comp href={milestone.link} className={styles.milestoneText} aria-label={milestone.text !== '???' ? milestone.text : undefined}>
       {milestone.img && (
         <div className={styles.icon}>
-          <img src={milestone.text === '???' ? 'https://cdn.polyhaven.com/vaults/icons/question.svg' : milestone.img} />
+          <img src={milestone.text === '???' ? 'https://cdn.polyhaven.com/vaults/icons/question.svg' : milestone.img} alt={milestone.text} />
         </div>
       )}
       <div
@@ -169,7 +169,7 @@ const Roadmap = ({ mini, vaults, addon }) => {
                     {!(mini || isMobile) && <div className={styles.arrow} />}
                     {(mini || isMobile) && m.img ? (
                       <div className={`${styles.dotImg} ${activeMilestoneIndex === i + 1 && styles.activeDot}`}>
-                        <img src={m.text === '???' ? 'https://cdn.polyhaven.com/vaults/icons/question.svg' : m.img} />
+                        <img src={m.text === '???' ? 'https://cdn.polyhaven.com/vaults/icons/question.svg' : m.img} alt={m.text} />
                       </div>
                     ) : (
                       <div className={styles.dot} />

--- a/components/UI/Avatar/Avatar.tsx
+++ b/components/UI/Avatar/Avatar.tsx
@@ -7,6 +7,7 @@ const Avatar = ({ id, size }) => {
       src={`https://cdn.polyhaven.com/people/${id}.jpg?width=${size}&quality=95`}
       width={size}
       height={size}
+      alt={id}
       onError={(e) => {
         const target = e.target as HTMLImageElement
         target.src = placeholderAvatar(id, size)

--- a/components/UI/Avatar/Patron.tsx
+++ b/components/UI/Avatar/Patron.tsx
@@ -9,7 +9,7 @@ const Avatar = ({ name, size, timestamp }) => {
   const { t } = useTranslation('time')
   return (
     <div className={styles.patron}>
-      <img src={avatar} width={size} height={size} />
+      <img src={avatar} width={size} height={size} alt={name} />
       <p>
         <strong>{name}</strong>
         <br />

--- a/components/UI/Avatar/Staff.tsx
+++ b/components/UI/Avatar/Staff.tsx
@@ -9,8 +9,8 @@ const Staff = ({ id, name, role, country, mode }) => {
 
   return (
     <div className={styles.staffAvatar}>
-      <Link href={`/all?a=${id}`}>
-        <img src={`https://cdn.polyhaven.com/people/${id}.jpg?width=${size}&quality=95`} width={size} height={size} />
+      <Link href={`/all?a=${id}`} aria-label={name}>
+        <img src={`https://cdn.polyhaven.com/people/${id}.jpg?width=${size}&quality=87`} width={size} height={size} alt={name} />
       </Link>
       <div className={`${styles.staffInfo} ${mode === 'compact' ? styles.staffInfoCompact : null}`}>
         <span lang="en" dir="ltr">

--- a/components/UI/Button/Button.tsx
+++ b/components/UI/Button/Button.tsx
@@ -2,9 +2,9 @@ import Link from 'next/link'
 
 import styles from './Button.module.scss'
 
-const Button = ({ text, href, color, icon, style }) => {
+const Button = ({ text, href, color, icon, style, ariaLabel }) => {
   return (
-    (<Link href={href} className={`${styles.button} ${styles[color]}`} style={style}>
+    (<Link href={href} className={`${styles.button} ${styles[color]}`} style={style} aria-label={ariaLabel}>
 
       <div className={styles.inner}>
         {icon && <div className={styles.icon}>{icon}</div>}
@@ -19,6 +19,7 @@ Button.defaultProps = {
   color: 'accent',
   icon: null,
   style: null,
+  ariaLabel: null,
 }
 
 export default Button

--- a/components/UI/Icons/CountryFlag.tsx
+++ b/components/UI/Icons/CountryFlag.tsx
@@ -1,7 +1,7 @@
 import ReactCountryFlag from 'react-country-flag'
 
 const CountryFlag = ({ code }) => {
-  return <ReactCountryFlag countryCode={code} svg style={{ width: 'inherit' }} />
+  return <ReactCountryFlag countryCode={code} svg style={{ width: 'inherit' }} title={code} alt={code} />
 }
 
 export default CountryFlag

--- a/components/UI/Icons/SocialIcons/SocialIcons.tsx
+++ b/components/UI/Icons/SocialIcons/SocialIcons.tsx
@@ -13,32 +13,32 @@ import styles from './SocialIcons.module.scss'
 const SocialIcons = () => {
   return (
     <div className={styles.communityIcons}>
-      <a href="https://discord.gg/Dms7Mrs">
+      <a href="https://discord.gg/Dms7Mrs" aria-label="Discord">
         <SiDiscord />
       </a>
-      <a href="https://www.patreon.com/polyhaven/overview">
+      <a href="https://www.patreon.com/polyhaven/overview" aria-label="Patreon">
         <SiPatreon />
       </a>
-      <a rel="me" href="https://masto.ai/@polyhaven">
+      <a rel="me" href="https://masto.ai/@polyhaven" aria-label="Mastodon">
         <SiMastodon />
       </a>
-      <a rel="me" href="https://bsky.app/profile/polyhaven.com">
+      <a rel="me" href="https://bsky.app/profile/polyhaven.com" aria-label="Bluesky">
         <SiBluesky />
       </a>
       <br />
-      <a href="https://www.facebook.com/polyhaven">
+      <a href="https://www.facebook.com/polyhaven" aria-label="Facebook">
         <SiFacebook />
       </a>
-      <a href="https://x.com/polyhaven">
+      <a href="https://x.com/polyhaven" aria-label="X">
         <SiX />
       </a>
-      <a href="https://www.instagram.com/polyhaven">
+      <a href="https://www.instagram.com/polyhaven" aria-label="Instagram">
         <SiInstagram />
       </a>
-      <a href="https://www.youtube.com/c/PolyHaven">
+      <a href="https://www.youtube.com/c/PolyHaven" aria-label="YouTube">
         <SiYoutube />
       </a>
-      <a href="https://api.polyhaven.com/rss">
+      <a href="https://api.polyhaven.com/rss" aria-label="RSS feed">
         <SiRss />
       </a>
     </div>

--- a/pages/[...assets].tsx
+++ b/pages/[...assets].tsx
@@ -12,9 +12,18 @@ import { titleCase } from 'utils/stringUtils'
 const LibraryPage = (props) => {
   const { t } = useTranslation('common')
 
-  let title = t(assetTypeName(props.assetType))
+  const typeDisplayName = {
+    hdris: 'HDRIs',
+    textures: 'PBR Textures',
+    models: '3D Models',
+    all: 'Assets',
+  }
+  const typeName = typeDisplayName[props.assetType] || t(assetTypeName(props.assetType))
+  let title: string
   if (props.categories.length) {
-    title += ': ' + titleCase(props.categories.join(' > '))
+    title = `${titleCase(props.categories[props.categories.length - 1])} ${typeName}`
+  } else {
+    title = typeName
   }
 
   let imageUrl = `https://polyhaven.com/api/og-image?type=${props.assetType}`

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -12,9 +12,9 @@ export default class CustomDocument extends Document {
         <Head>
           <link rel="icon" href="/favicon.ico" />
 
-          <link rel="preconnect" href="https://fonts.gstatic.com" />
-          <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap" rel="stylesheet" />
-          <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+          <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap&font-display=swap" rel="stylesheet" />
+          <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css" media="print" onLoad="this.media='all'" />
 
           <meta property="og:locale" content="en_US" />
           <meta property="og:type" content="website" />
@@ -25,9 +25,9 @@ export default class CustomDocument extends Document {
           <meta property="commit_hash" content={process.env.CONFIG_BUILD_ID} />
 
           {/* Download service worker */}
-          <script src="/download-js/ua-parser.min.js"></script>
-          <script src="/download-js/zip.js"></script>
-          <script src="/download-js/download.js"></script>
+          <script defer src="/download-js/ua-parser.min.js"></script>
+          <script defer src="/download-js/zip.js"></script>
+          <script defer src="/download-js/download.js"></script>
         </Head>
 
         <body>

--- a/pages/a/[id].tsx
+++ b/pages/a/[id].tsx
@@ -24,17 +24,96 @@ const Page = ({ assetID, data, files, renders, postDownloadStats }) => {
       </ErrorPage>
     )
   }
+
+  const fullUrl = `https://polyhaven.com${pageUrl}`
+  const description = data.description || `Download this free ${assetTypeName(data.type, false)} from Poly Haven`
+
+  const renderImageName = (assetName: string, filename: string): string => {
+    const f = filename.toLowerCase()
+    const typeSuffix = (data.type === 2 ? '3D Model' : assetTypeName(data.type, false)) + ' render'
+    if (f === 'clay.png') return `${assetName} wireframe clay ${typeSuffix}`
+    if (f.startsWith('orth_front')) return `${assetName} front view ${typeSuffix}`
+    if (f.startsWith('orth_side')) return `${assetName} side view ${typeSuffix}`
+    if (f.startsWith('orth_top')) return `${assetName} top view ${typeSuffix}`
+    if (f.startsWith('orth_back')) return `${assetName} back view ${typeSuffix}`
+    if (f.startsWith('orth_')) return `${assetName} orthographic ${typeSuffix}`
+    if (f.startsWith('cam_')) return `${assetName} ${typeSuffix}`
+    if (/(reference|context)/i.test(f)) return `${assetName} reference ${typeSuffix}`
+    return `${assetName} ${typeSuffix}`
+  }
+
+  const renderImages = renders
+    ? Object.keys(renders).map((filename) => {
+        const meta = typeof renders[filename] === 'object' ? renders[filename] : {}
+        return {
+          '@type': 'ImageObject',
+          contentUrl: `https://cdn.polyhaven.com/asset_img/renders/${assetID}/${filename}`,
+          name: meta.title || renderImageName(data.name, filename),
+          ...(meta.author ? { creditText: meta.author } : {}),
+          ...(meta.url ? { acquireLicensePage: meta.url } : {}),
+        }
+      })
+    : []
+
+  const primaryImage = {
+    '@type': 'ImageObject',
+    contentUrl: `https://cdn.polyhaven.com/asset_img/primary/${assetID}.png`,
+    name: `${data.name} preview`,
+  }
+
+  const diffuseImage =
+    data.type === 1 && files?.Diffuse
+      ? (() => {
+          const resolutions = ['1k', '2k', '4k']
+          for (const res of resolutions) {
+            const url = files.Diffuse[res]?.jpg?.url
+            if (url) {
+              return {
+                '@type': 'ImageObject',
+                contentUrl: url,
+                name: `${data.name} seamless PBR texture diffuse map`,
+              }
+            }
+          }
+          return null
+        })()
+      : null
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': data.type === 2 ? '3DModel' : 'CreativeWork',
+    name: data.name,
+    description,
+    url: fullUrl,
+    keywords: [...data.categories, ...data.tags].join(', '),
+    license: 'https://creativecommons.org/publicdomain/zero/1.0/',
+    isAccessibleForFree: true,
+    author: Object.keys(data.authors).map((name) => ({ '@type': 'Person', name })),
+    image: [primaryImage, ...renderImages, ...(diffuseImage ? [diffuseImage] : [])],
+    ...(data.type === 2
+      ? {
+          encodingFormat: 'model/gltf-binary',
+          additionalType: `https://schema.org/3DModel`,
+        }
+      : {}),
+  }
+
   return (
     <div className="content">
       <Head
-        title={`${data.name} ${assetTypeName(data.type, false)}`}
-        description={data.description || `Download this free ${assetTypeName(data.type, false)} from Poly Haven`}
+        title={`${data.name} ${data.type === 2 ? '3D Model' : data.type === 1 ? 'PBR Texture' : assetTypeName(data.type, false)}`}
+        description={description}
         url={pageUrl}
         assetType={data.type}
         author={Object.keys(data.authors).join(', ')}
         keywords={`${data.categories.join(',')},${data.tags.join(',')}`}
         image={`https://cdn.polyhaven.com/asset_img/thumbs/${assetID}.png?width=630&quality=95`}
-      />
+      >
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </Head>
       <div>
         <AssetPage
           assetID={assetID}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -63,6 +63,8 @@
     "api": "API",
     "source": "Source",
     "logout": "Logout",
+    "login": "Login",
+    "account": "Account",
     "collections": "Collections",
     "logo": "Logo"
   },

--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -31,6 +31,7 @@
   "s6p4": "If you like what we do and want to keep this site alive, consider <lnk>supporting us on Patreon</lnk>.",
   "s7": "Community Renders:",
   "s7b": "More",
+  "s7b_aria": "More community renders",
   "s8t": "Join the Community",
   "s8p1": "Poly Haven is <strong>your</strong> community project.",
   "s8p2": "Everything we do, we do with your help, for the greater 3D community."


### PR DESCRIPTION
- Add semantic HTML elements (header, nav, main, footer)
- Add missing alt text and aria-labels
- Add JSON-LD schema.org structured data to asset pages, enabling search engines to properly index asset metadata (images, authors, license, type)
- Improve page titles for asset type/category pages
- Reduce image quality from 95 to 87 for some images and thumbnails
- Dynamic preview image sizing based on container width (AssetPage)
- Fix carousel height to prevent layout shift
- Async CSS and deferred scripts in _document
- Fix Download button href=null broken link
- Add "More community renders" as screen-reader-only aria-label on gallery button

These changes fix many issues shown on https://pagespeed.web.dev/ which helps rank better in search results.